### PR TITLE
[Control Point] Rename "finalize" to "stop-service"

### DIFF
--- a/src/control-point.h
+++ b/src/control-point.h
@@ -33,7 +33,6 @@ typedef void (*dleyna_control_point_initialize_t)(
 					const dleyna_connector_t *connector,
 					dleyna_task_processor_t *processor,
 					dleyna_settings_t *settings);
-typedef void (*dleyna_control_point_finalize_t)(void);
 typedef void (*dleyna_control_point_free_t)(void);
 
 typedef const gchar *(*dleyna_control_point_server_name_t)(void);
@@ -42,16 +41,17 @@ typedef const gchar *(*dleyna_control_point_root_introspection_t)(void);
 
 typedef gboolean (*dleyna_control_point_start_service_t)(
 					dleyna_connector_id_t connection);
+typedef void (*dleyna_control_point_stop_service_t)(void);
 
 typedef struct dleyna_control_point_t_ dleyna_control_point_t;
 struct dleyna_control_point_t_ {
 	dleyna_control_point_initialize_t initialize;
-	dleyna_control_point_finalize_t finalize;
 	dleyna_control_point_free_t free;
 	dleyna_control_point_server_name_t server_name;
 	dleyna_control_point_server_introspection_t server_introspection;
 	dleyna_control_point_root_introspection_t root_introspection;
 	dleyna_control_point_start_service_t start_service;
+	dleyna_control_point_stop_service_t stop_service;
 };
 
 #endif /* DLEYNA_CONTROL_POINT_H__ */

--- a/src/main-loop.c
+++ b/src/main-loop.c
@@ -58,7 +58,7 @@ static gboolean prv_context_quit_cb(gpointer user_data)
 	DLEYNA_LOG_DEBUG("Quitting");
 
 	g_context.connector->disconnect();
-	g_context.control_point->finalize();
+	g_context.control_point->stop_service();
 
 	g_timeout_add_seconds(1, prv_context_mainloop_quit_cb, NULL);
 


### PR DESCRIPTION
This name is a better choice and symmetric with the existing functions:

initialize()
    start_service()
    stop_service()
free()
