### PR TITLE
Add gmodule-2.0 to .pc dependencies

### DIFF
--- a/dleyna-core-1.0.pc.in
+++ b/dleyna-core-1.0.pc.in
@@ -8,5 +8,5 @@ Name: @PACKAGE@
 Description: UPnP & DLNA core library
 Libs: -L${libdir} -ldleyna-core-1.0
 Cflags: -I${includedir}/dleyna-1.0
-Requires: glib-2.0 gio-2.0
+Requires: glib-2.0 gio-2.0 gmodule-2.0
 Version: @VERSION@


### PR DESCRIPTION
Without this compiling -server and -renderer may fail when GModule symbols are not found.

Signed-off-by: Jussi Kukkonen jussi.kukkonen@intel.com
