### PR TITLE
[Processor] Handle empty queue start()

### DIFF
--- a/libdleyna/core/task-processor.c
+++ b/libdleyna/core/task-processor.c
@@ -379,7 +379,7 @@ void dleyna_task_queue_start(const dleyna_task_queue_key_t *queue_id)
 	DLEYNA_LOG_DEBUG("Enter - Starting queue <%s,%s>", queue_id->source,
 			 queue_id->sink);
 
-	queue = g_hash_table_lookup(queue_id->processor->task_queues, queue_id);
+	queue = g_hash_table_lookup(processor->task_queues, queue_id);
 
 	if (queue->defer_remove)
 		goto exit;


### PR DESCRIPTION
This case should not happen in the existing code, but this PR fixes a use case that would crash if we start() an empty queue.
