### PR TITLE
[Build] Add autogen.sh script to call `autoreconf -i`

### DIFF
--- a/README
+++ b/README
@@ -19,8 +19,7 @@ follows:
      # cd dleyna-core
 
    Configure and build
-     # ./autoreconf -i
-     # ./configure
+     # ./autogen.sh
      # make
 
    Final installation

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Run this to generate all the initial makefiles, etc.
+# Derived from https://git.gnome.org/browse/glib/tree/autogen.sh
+
+test -n "$srcdir" || srcdir=`dirname "$0"`
+test -n "$srcdir" || srcdir=.
+
+olddir=`pwd`
+cd "$srcdir"
+
+AUTORECONF=`which autoreconf`
+if test -z $AUTORECONF; then
+        echo "*** No autoreconf found, please install it ***"
+        exit 1
+fi
+
+autoreconf --force --install --verbose || exit $?
+
+cd "$olddir"
+test -n "$NOCONFIGURE" || "$srcdir/configure" "$@"

--- a/bootstrap-configure
+++ b/bootstrap-configure
@@ -4,8 +4,7 @@ if [ -f config.status ]; then
 	make maintainer-clean
 fi
 
-autoreconf -if && \
-    ./configure --enable-maintainer-mode \
+./autogen.sh --enable-maintainer-mode \
 		--enable-silent-rules \
 		--disable-optimization \
 		--enable-debug \


### PR DESCRIPTION
Even when using autoreconf an autogen.sh script is usually expected, as
it save users from needing to know which flags to pass to autoreconf
(ie. '-i').

It is also usually responsible of launching autogen from the right
directory, calling utilities like intltoolize and gtkdocize, checking
out git submodules and running ./configure if $NOCONFIGURE is not set.

Signed-off-by: Emanuele Aina emanuele.aina@collabora.com
