### PR TITLE
[Connector] Change publish_object() signature

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ([2.66])
 
 AC_INIT([dleyna-core],
-	[0.2.0],
+	[0.2.1],
 	[https://github.com/01org/dleyna-core/issues/new],
 	,
 	[https://01.org/dleyna/])

--- a/libdleyna/core/connector.h
+++ b/libdleyna/core/connector.h
@@ -67,7 +67,7 @@ typedef guint (*dleyna_connector_publish_object_t)(
 			dleyna_connector_id_t connection,
 			const gchar *object_path,
 			gboolean root,
-			guint interface_index,
+			const gchar* interface_name,
 			const dleyna_connector_dispatch_cb_t *cb_table_1);
 typedef guint (*dleyna_connector_publish_subtree_t)(
 				dleyna_connector_id_t connection,


### PR DESCRIPTION
The interface_index parameter relates to the corresponding xml
part from the introspection data passed to initialize().
This was convenient for the d-bus connector implementation, but
required xml parsing for other connector implementations.

This commit replaces the interface_index parameter with the
actual interface name to avoid the xml parsing task.

Signed-off-by: Regis Merlino regis.merlino@intel.com
