### PR TITLE
[Control Point] Get version from the control point lib

### DIFF
--- a/libdleyna/core/control-point.h
+++ b/libdleyna/core/control-point.h
@@ -38,6 +38,7 @@ typedef void (*dleyna_control_point_free_t)(void);
 typedef const gchar *(*dleyna_control_point_server_name_t)(void);
 typedef const gchar *(*dleyna_control_point_server_introspection_t)(void);
 typedef const gchar *(*dleyna_control_point_root_introspection_t)(void);
+typedef const gchar *(*dleyna_control_point_get_version_t)(void);
 
 typedef gboolean (*dleyna_control_point_start_service_t)(
 					dleyna_connector_id_t connection);
@@ -52,6 +53,7 @@ struct dleyna_control_point_t_ {
 	dleyna_control_point_root_introspection_t root_introspection;
 	dleyna_control_point_start_service_t start_service;
 	dleyna_control_point_stop_service_t stop_service;
+	dleyna_control_point_get_version_t get_version;
 };
 
 #endif /* DLEYNA_CONTROL_POINT_H__ */

--- a/libdleyna/core/main-loop.c
+++ b/libdleyna/core/main-loop.c
@@ -120,7 +120,6 @@ static void prv_context_free(void)
 }
 
 int dleyna_main_loop_start(const char *server,
-			   const char *version,
 			   const dleyna_control_point_t *control_point,
 			   gpointer user_data)
 {
@@ -130,7 +129,7 @@ int dleyna_main_loop_start(const char *server,
 	g_type_init();
 #endif
 
-	dleyna_log_init(server, version);
+	dleyna_log_init(server, control_point->get_version());
 
 	if (!prv_context_init(server, control_point))
 		goto out;

--- a/libdleyna/core/main-loop.h
+++ b/libdleyna/core/main-loop.h
@@ -27,7 +27,6 @@
 #include "control-point.h"
 
 int dleyna_main_loop_start(const char *server,
-			   const char *version,
 			   const dleyna_control_point_t *control_point,
 			   gpointer user_data);
 void dleyna_main_loop_quit(void);


### PR DESCRIPTION
Fix issue #29.

We currently log the daemon version string, but the control point version string should be printed instead.
The full fix requires changes in dleyna-core, dleyna-server & dleyna-renderer.
This PR is the first step.
