### PR TITLE
[Autoconf] Add --no-undefined to compiler option

### DIFF
--- a/m4/compiler-flags.m4
+++ b/m4/compiler-flags.m4
@@ -52,4 +52,5 @@ AC_DEFUN_ONCE([DLEYNA_CORE_COMPILER_FLAGS], [
 	fi
 
 	CFLAGS+=" -Wno-format-extra-args"
+	CFLAGS+=" -Wl,--no-undefined"
 ])


### PR DESCRIPTION
Update the compiler flags to enable the check of undefined function at link time.

It seems the option '-no-undefined' pass in libdleyna_core_1_0_la_LDFLAGS
is not enough. Using libtool, this option should be set to the compiler flags.

Signed-off-by: Ludovic Ferrandis ludovic.ferrandis@intel.com
