### PR TITLE
[Settings] Update: Save, monitoring, notification

### DIFF
--- a/libdleyna/core/settings.h
+++ b/libdleyna/core/settings.h
@@ -31,10 +31,24 @@ void dleyna_settings_new(const gchar *server, dleyna_settings_t **settings);
 
 void dleyna_settings_delete(dleyna_settings_t *settings);
 
-void dleyna_settings_init_white_list(dleyna_settings_t *settings);
+const gchar *dleyna_settings_connector_name(dleyna_settings_t *settings);
 
 gboolean dleyna_settings_is_never_quit(dleyna_settings_t *settings);
 
-const gchar *dleyna_settings_connector_name(dleyna_settings_t *settings);
+void dleyna_settings_set_never_quit(dleyna_settings_t *settings,
+				    gboolean never_quit,
+				    GError **error);
+
+gboolean dleyna_settings_is_white_list_enabled(dleyna_settings_t *settings);
+
+void dleyna_settings_set_white_list_enabled(dleyna_settings_t *settings,
+					    gboolean enabled,
+					    GError **error);
+
+GVariant *dleyna_settings_white_list_entries(dleyna_settings_t *settings);
+
+void dleyna_settings_set_white_list_entries(dleyna_settings_t *settings,
+					    GVariant *entries,
+					    GError **error);
 
 #endif /* DLEYNA_SETTINGS_H__ */

--- a/libdleyna/core/white-list.h
+++ b/libdleyna/core/white-list.h
@@ -26,25 +26,19 @@
 #include <glib.h>
 #include <libgupnp/gupnp-white-list.h>
 
-typedef void (*dleyna_white_list_notify_t)(gpointer user_data);
-
 typedef struct dleyna_white_list_t_ dleyna_white_list_t;
 
-struct dleyna_white_list_t_ {
-	GUPnPWhiteList *wl;
-	dleyna_white_list_notify_t cb_enabled;
-	dleyna_white_list_notify_t cb_entries;
-	gpointer user_data;
-};
+dleyna_white_list_t *dleyna_white_list_new(GUPnPWhiteList *gupnp_wl);
 
-void dleyna_white_list_enable(gboolean enabled, gboolean notify);
+void dleyna_white_list_delete(dleyna_white_list_t *wl);
 
-void dleyna_white_list_add_entries(GVariant *entries, gboolean notify);
+void dleyna_white_list_enable(dleyna_white_list_t *wl, gboolean enabled);
 
-void dleyna_white_list_remove_entries(GVariant *entries, gboolean notify);
+void dleyna_white_list_add_entries(dleyna_white_list_t *wl, GVariant *entries);
 
-void dleyna_white_list_clear(gboolean notify);
+void dleyna_white_list_remove_entries(dleyna_white_list_t *wl,
+				      GVariant *entries);
 
-void dleyna_white_list_set_info(dleyna_white_list_t *data);
+void dleyna_white_list_clear(dleyna_white_list_t *wl);
 
 #endif /* DLEYNA_WHITE_LIST_H__ */


### PR DESCRIPTION
Make settings & white list independant.
Settings doesn't call directly WhiteList API.

Settings 'never_quit' & 'netf_enabled' & 'netf_entries' are now save to the settings file
when set using the new API below:
- dleyna-settings_set_never_quit
- dleyna_settings_set_white_list_enabled
- dleyna_settings_set_white_list_entries

Monitoring has been removed.

Signed-off-by: Ludovic Ferrandis ludovic.ferrandis@intel.com
