### PR TITLE
[Warnings] Fix compile warnings on ARM

### DIFF
--- a/libdleyna/core/service-task.c
+++ b/libdleyna/core/service-task.c
@@ -125,7 +125,7 @@ void dleyna_service_task_delete_cb(dleyna_task_atom_t *atom, gpointer user_data)
 	g_free(task);
 }
 
-gpointer *dleyna_service_task_get_user_data(dleyna_service_task_t *task)
+gpointer dleyna_service_task_get_user_data(dleyna_service_task_t *task)
 {
 	return task->user_data;
 }

--- a/libdleyna/core/service-task.h
+++ b/libdleyna/core/service-task.h
@@ -58,6 +58,6 @@ void dleyna_service_task_cancel_cb(dleyna_task_atom_t *atom,
 void dleyna_service_task_delete_cb(dleyna_task_atom_t *atom,
 				   gpointer user_data);
 
-gpointer *dleyna_service_task_get_user_data(dleyna_service_task_t *task);
+gpointer dleyna_service_task_get_user_data(dleyna_service_task_t *task);
 
 #endif /* DLEYNA_SERVICE_TASK_H__ */

--- a/libdleyna/core/task-atom.h
+++ b/libdleyna/core/task-atom.h
@@ -27,7 +27,7 @@ typedef struct dleyna_task_queue_key_t_ dleyna_task_queue_key_t;
 
 struct dleyna_task_atom_t_ {
 	const dleyna_task_queue_key_t *queue_id;
-};
+} __attribute__((aligned));
 typedef struct dleyna_task_atom_t_ dleyna_task_atom_t;
 
 #endif /* DLEYNA_TASK_ATOM_H__ */


### PR DESCRIPTION
Partial fix for https://github.com/01org/dleyna-renderer/issues/137

The signature of dleyna_service_task_get_user_data was wrong and has
now been fixed.

We also need to align structures in virtual inheritence hierarchies.

Signed-off-by: Mark Ryan mark.d.ryan@intel.com
