### PR TITLE
settings: Add "port" setting

### DIFF
--- a/libdleyna/core/settings.c
+++ b/libdleyna/core/settings.c
@@ -36,6 +36,7 @@ struct dleyna_settings_t_ {
 	gboolean never_quit;
 	gchar *connector_name;
 	guint port;
+	guint push_host_port;
 
 	/* Log section */
 	dleyna_log_type_t log_type;
@@ -50,6 +51,7 @@ struct dleyna_settings_t_ {
 #define DLEYNA_SETTINGS_KEY_NEVER_QUIT		"never-quit"
 #define DLEYNA_SETTINGS_KEY_CONNECTOR_NAME	"connector-name"
 #define DLEYNA_SETTINGS_KEY_PORT		"port"
+#define DLEYNA_SETTINGS_KEY_PUSH_HOST_PORT	"push-host-port"
 
 #define DLEYNA_SETTINGS_GROUP_LOG		"log"
 #define DLEYNA_SETTINGS_KEY_LOG_TYPE		"log-type"
@@ -79,6 +81,8 @@ do { \
 	DLEYNA_LOG_INFO("Connector Name: %s", (settings)->connector_name);\
 	DLEYNA_LOG_DEBUG_NL(); \
 	DLEYNA_LOG_INFO("Port: %u", (settings)->port);\
+	DLEYNA_LOG_DEBUG_NL(); \
+	DLEYNA_LOG_INFO("Push host port: %u", (settings)->push_host_port);\
 	DLEYNA_LOG_DEBUG_NL(); \
 	\
 	DLEYNA_LOG_INFO("[Logging settings]"); \
@@ -291,6 +295,18 @@ static void prv_read_keys(dleyna_settings_t *settings)
 		error = NULL;
 	}
 
+	u_val = g_key_file_get_uint64(keyfile,
+				      DLEYNA_SETTINGS_GROUP_GENERAL,
+				      DLEYNA_SETTINGS_KEY_PUSH_HOST_PORT,
+				      &error);
+
+	if (error == NULL) {
+		settings->push_host_port = (guint)u_val;
+	} else {
+		g_error_free(error);
+		error = NULL;
+	}
+
 	int_val = g_key_file_get_integer(keyfile,
 					 DLEYNA_SETTINGS_GROUP_LOG,
 					 DLEYNA_SETTINGS_KEY_LOG_TYPE,
@@ -352,6 +368,7 @@ static void prv_init_default(dleyna_settings_t *settings)
 	settings->connector_name = g_strdup(
 					DLEYNA_SETTINGS_DEFAULT_CONNECTOR_NAME);
 	settings->port = 0;
+	settings->push_host_port = 0;
 
 	settings->log_type = DLEYNA_SETTINGS_DEFAULT_LOG_TYPE;
 	settings->log_level = DLEYNA_SETTINGS_DEFAULT_LOG_LEVEL;
@@ -447,6 +464,11 @@ const gchar *dleyna_settings_connector_name(dleyna_settings_t *settings)
 guint dleyna_settings_port(dleyna_settings_t *settings)
 {
 	return settings->port;
+}
+
+guint dleyna_settings_push_host_port(dleyna_settings_t *settings)
+{
+	return settings->push_host_port;
 }
 
 static void prv_save_settings_to_file(dleyna_settings_t *settings,

--- a/libdleyna/core/settings.h
+++ b/libdleyna/core/settings.h
@@ -37,6 +37,8 @@ gboolean dleyna_settings_is_never_quit(dleyna_settings_t *settings);
 
 guint dleyna_settings_port(dleyna_settings_t *settings);
 
+guint dleyna_settings_push_host_port(dleyna_settings_t *settings);
+
 void dleyna_settings_set_never_quit(dleyna_settings_t *settings,
 				    gboolean never_quit,
 				    GError **error);


### PR DESCRIPTION
Signed-off-by: Jussi Kukkonen jussi.kukkonen@intel.com

This exposes a configuration setting and the idea is that GUPnPContextManager port is set accordingly.

I'm sending the renderer/server patches in a minute
