### PR TITLE
Search connectors in DLEYNA_CONNECTOR_PATH

### DIFF
--- a/libdleyna/core/connector-mgr.c
+++ b/libdleyna/core/connector-mgr.c
@@ -34,33 +34,54 @@ const dleyna_connector_t *dleyna_connector_mgr_load(const gchar *name)
 	const dleyna_connector_t *connector;
 	dleyna_connector_get_interface_t get_interface;
 	gchar *path;
+	const gchar *connector_path;
+	gchar **connector_path_list;
+	gsize i;
 
 	DLEYNA_LOG_DEBUG("Enter");
 
-	path = g_strdup_printf("%s/%s%s.so", CONNECTOR_DIR,
-			       DLEYNA_CONNECTOR_LIB_PATTERN, name);
-	module = g_module_open(path, G_MODULE_BIND_LAZY);
-	g_free(path);
-
-	if (module) {
-		if (!g_connectors)
-			g_connectors = g_hash_table_new(g_direct_hash,
-							g_direct_equal);
-
-		if (g_module_symbol(module, "dleyna_connector_get_interface",
-				    (gpointer *)&get_interface)) {
-			connector = get_interface();
-			g_hash_table_insert(g_connectors, (gpointer)connector,
-					    module);
-		} else {
-			connector = NULL;
-			g_module_close(module);
-			DLEYNA_LOG_CRITICAL(
-					"Connector '%s' entry point not found",
-					name);
-		}
-
+	connector_path = g_getenv ("DLEYNA_CONNECTOR_PATH");
+	if (!connector_path) {
+		DLEYNA_LOG_DEBUG ("DLEYNA_CONNECTOR_PATH not set");
+		connector_path = CONNECTOR_DIR;
 	} else {
+		DLEYNA_LOG_DEBUG ("DLEYNA_CONNECTOR_PATH set to %s", connector_path);
+	}
+
+	connector_path_list = g_strsplit (connector_path, G_SEARCHPATH_SEPARATOR_S, 0);
+
+	for (i = 0; connector_path_list[i]; i++) {
+		path = g_strdup_printf("%s/%s%s.so", connector_path_list[i],
+				       DLEYNA_CONNECTOR_LIB_PATTERN, name);
+		module = g_module_open(path, G_MODULE_BIND_LAZY);
+		g_free(path);
+
+		if (module) {
+			if (!g_connectors)
+				g_connectors = g_hash_table_new(g_direct_hash,
+								g_direct_equal);
+
+			if (g_module_symbol(module, "dleyna_connector_get_interface",
+					    (gpointer *)&get_interface)) {
+				connector = get_interface();
+				g_hash_table_insert(g_connectors, (gpointer)connector,
+						    module);
+
+				break;
+			} else {
+				connector = NULL;
+				g_module_close(module);
+				DLEYNA_LOG_CRITICAL(
+						"Connector '%s' entry point not found",
+						name);
+			}
+
+		}
+	}
+
+	g_strfreev (connector_path_list);
+
+	if (!module) {
 		connector = NULL;
 		DLEYNA_LOG_CRITICAL("Connector '%s' not found", name);
 	}


### PR DESCRIPTION
Previously, the connectors would only be looked for in a single directory, specified during compilation. This patch allows to traverse a list of directories provided by an environment variable.

We need it for NixOS where packages are installed into read-only tree so the different connectors cannot be placed into a single directory.